### PR TITLE
Fix up heart rate example

### DIFF
--- a/examples/heartrate-monitor/main.go
+++ b/examples/heartrate-monitor/main.go
@@ -86,7 +86,7 @@ func main() {
 	println("found characteristic", char.UUID().String())
 
 	char.EnableNotifications(func(buf []byte) {
-		println("data:", uint8(buf[0]))
+		println("data:", uint8(buf[1]))
 	})
 
 	select {}

--- a/examples/heartrate/main.go
+++ b/examples/heartrate/main.go
@@ -18,7 +18,7 @@ func main() {
 	adv := adapter.DefaultAdvertisement()
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName:    "Go HRS",
-		ServiceUUIDs: []bluetooth.UUID{bluetooth.New16BitUUID(0x2A37)},
+		ServiceUUIDs: []bluetooth.UUID{bluetooth.New16BitUUID(0x180D)},
 	}))
 	must("start adv", adv.Start())
 
@@ -30,17 +30,7 @@ func main() {
 				Handle: &heartRateMeasurement,
 				UUID:   bluetooth.New16BitUUID(0x2A37), // Heart Rate Measurement
 				Value:  []byte{0, heartRate},
-				Flags: bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission |
-					bluetooth.CharacteristicNotifyPermission,
-				WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
-					if offset != 0 || len(value) < 2 {
-						return
-					}
-					if value[1] != 0 { // avoid divide by zero
-						heartRate = value[1]
-						println("heart rate is now:", heartRate)
-					}
-				},
+				Flags: bluetooth.CharacteristicNotifyPermission,
 			},
 		},
 	}))
@@ -55,7 +45,7 @@ func main() {
 		heartRate = randomInt(65, 85)
 
 		// and push the next notification
-		heartRateMeasurement.Write([]byte{byte(heartRate)})
+		heartRateMeasurement.Write([]byte{0, heartRate})
 	}
 }
 


### PR DESCRIPTION
Fix up the heart rate example so that it conforms to the Heart Rate Service specification: https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=239866

This will let this example work with external clients like exercise equipment and fitness apps.

Changes:
- Advertise the HR service UUID instead of the HRM characteristic UUID.
- Change HRM characteristic to notify only.
- HRM payload needs to be two bytes:
  - 1st byte is flags specifying data type and sensor capabilities: this can be set to zero.
  - 2nd byte is HR measurement in bpm.

Tested on Raspberry Pi with nRF Connect app and exercise bike. Peripheral shows up as HR monitor and data is interpreted correctly.